### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/hyzr-sec/animatch/security/code-scanning/1](https://github.com/hyzr-sec/animatch/security/code-scanning/1)

To fix the issue, the workflow should include a `permissions` block at the root or job level to explicitly define the minimum necessary permissions. Since the workflow interacts with the repository's contents (e.g., commits and pulls code), it requires `contents: write` permission. Adding this block ensures that the GITHUB_TOKEN is scoped properly and adheres to the principle of least privilege.

The `permissions` block should be added at the `jobs.deploy` level to minimize the permissions scope specifically for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
